### PR TITLE
Change mentions of traditional to Bare-metal where necessary

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -38,7 +38,7 @@ To install AzuraCast, you should have a basic understanding of the Linux shell t
 
 ### What's Included
 
-Whether you're using the traditional installer or Docker containers, AzuraCast will automatically retrieve and install these components for you:
+Whether you're using the Bare-metal installer or Docker containers, AzuraCast will automatically retrieve and install these components for you:
 
 #### Radio Software
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ If you're using the Docker installation method, it's recommended to download the
 docker-compose run --rm cli azuracast_cli [command]
 ```
 
-**Traditional Installation:**
+**Bare-metal Installation:**
 
 ```bash
 php /var/azuracast/www/util/cli.php [command]

--- a/docs/install.md
+++ b/docs/install.md
@@ -77,4 +77,4 @@ Our friends at DigitalOcean offer fast, affordable, scalable hosting that is per
 If you are hosting your installation with Linode, you can take advantage of these community-maintained scripts to automate the installation process. These scripts can also be found from the Linode manager's "Community StackScripts" section:
 
 - [Linode Docker Installer StackScript](https://www.linode.com/stackscripts/view/352549)
-- [Linode Traditional Installer StackScript](https://www.linode.com/stackscripts/view/352555)
+- [Linode Bare-metal Installer StackScript](https://www.linode.com/stackscripts/view/352555)

--- a/docs/install_traditional.md
+++ b/docs/install_traditional.md
@@ -14,7 +14,7 @@ Currently, the following operating systems are supported:
 - Ubuntu 18.04 "Bionic" LTS
 
 ::: tip
-Some web hosts offer custom versions of Ubuntu that include different software repositories. These may cause compatibility issues with AzuraCast. Many VPS providers are known to work out of the box with AzuraCast (OVH, DigitalOcean, Vultr, etc), and are thus highly recommended if you plan to use the traditional installer.
+Some web hosts offer custom versions of Ubuntu that include different software repositories. These may cause compatibility issues with AzuraCast. Many VPS providers are known to work out of the box with AzuraCast (OVH, DigitalOcean, Vultr, etc), and are thus highly recommended if you plan to use the Bare-metal installer.
 :::
 
 AzuraCast is optimized for speed and performance, and can run on very inexpensive hardware, from the Raspberry Pi 3 to the lowest-level VPSes offered by most providers.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -24,7 +24,7 @@ By default, all AzuraCast installations will send only the following limited sub
 
 - Randomized AzuraCast instance ID
 - SHA hash of the current version of AzuraCast that is running
-- The platform that the AzuraCast instance is running from (Docker or Traditional)
+- The platform that the AzuraCast instance is running from (Docker or Bare-metal)
 - The public IP address of the self-hosted AzuraCast instance
 
 This information is collected and stored on AzuraCast servers for the sole purposes of tracking the number of installations across the Web using a specific version and platform of the software, and informing station operators of any important updates or announcements.


### PR DESCRIPTION
I've changed all mentions of traditional installations (where necessary) to Bare-metal since we are not recommending using this installation method as the standard way to install AzuraCast and the previous naming was causing some confusion for new users on what they should use.