### PR TITLE
Modifying docker - add example showing how we can preserve old stream urls using Nginx proxy

### DIFF
--- a/docs/extending/modifying-docker.md
+++ b/docs/extending/modifying-docker.md
@@ -105,8 +105,8 @@ services:
     volumes_from:
       - nginx_proxy
     volumes:
-      - letsencrypt:/etc/nginx/certs
-      - ./old_streams_proxy.conf:/etc/nginx/conf.d/old_streams_proxy.conf
+      - letsencrypt:/etc/nginx/certs:ro
+      - ./old_streams_proxy.conf:/etc/nginx/conf.d/old_streams_proxy.conf:ro
     ports:
       - "5000:5000"
 ```


### PR DESCRIPTION
This is my solution for https://github.com/AzuraCast/AzuraCast/issues/2947 and I would like to share it. If this isn't the appropriate place for it, that's ok. I just want to share it with Azuracast maintainers in case you find it useful. I also realize that you may not want to support this kind of thing and that would be very understandable (especially the Nginx hack that allows http+https traffic on the same port). But I feel like I'm not the only one migrating from an existing system who wants to preserve our old urls. Why preserve old urls? When your station exists for 10+ years like ours, you likely have had 3rd parties hard code your stream urls. You probably don't even know who most of these 3rd parties are but you would like to keep the traffic. If you can relate, then this is for you. The example is quite straightforward. If this is deemed appropriate, awesome. If not, that's ok too. Hopefully someone finds it useful or inspirational. Thank you @SlvrEagle23 and other maintainers for your work.