### PR TITLE
/live/nowplaying/station_shortcode not station_id

### DIFF
--- a/docs/developers/nowplaying.md
+++ b/docs/developers/nowplaying.md
@@ -161,7 +161,7 @@ To use this API method on a web site, first make sure the [Nchan Subscriber Java
 An example implementation using the Nchan Subscriber library might look like:
 
 ```javascript
-var sub = new NchanSubscriber('http://your-azuracast-site.example.com/api/live/nowplaying/station_id');
+var sub = new NchanSubscriber('http://your-azuracast-site.example.com/api/live/nowplaying/station_shortcode');
 var nowPlaying;
 
 sub.on("message", function(message, message_metadata) {


### PR DESCRIPTION
As far as I can tell the websocket api does not allow station_id's
If I am wrong in my testing this should still be documented better?