### PR TITLE
Update documentation about mounting custom SSL certificates

### DIFF
--- a/docs/extending/letsencrypt.md
+++ b/docs/extending/letsencrypt.md
@@ -51,7 +51,7 @@ services:
 
   stations:
     volumes:
-      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.key:ro
+      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.crt:ro
       - /path/on/host/to/ssl.key:/etc/nginx/certs/yourdomain.com.key:ro
 ```
 

--- a/docs/extending/letsencrypt.md
+++ b/docs/extending/letsencrypt.md
@@ -17,7 +17,7 @@ LetsEncrypt is a free and simple way to allow safe and secure connections to you
 
 Before setting up LetsEncrypt, you should make sure the following conditions are met:
 
- - **AzuraCast must be on its own domain or subdomain.** You can't set up LetsEncrypt using only an IP address; you must have a domain (i.e. `mysite.com`) or a subdomain (`radio.mysite.com`) set up to point to your AzuraCast installation. 
+ - **AzuraCast must be on its own domain or subdomain.** You can't set up LetsEncrypt using only an IP address; you must have a domain (i.e. `mysite.com`) or a subdomain (`radio.mysite.com`) set up to point to your AzuraCast installation.
  - **AzuraCast's web server must be served on the default ports, 80 for HTTP and 443 for HTTPS.** By default, AzuraCast is already set up this way, but if you've modified the ports to serve the site on a secondary port, you must switch the ports back to the defaults when setting up LetsEncrypt and when performing renewals.
 
 ## Enabling LetsEncrypt
@@ -47,6 +47,11 @@ services:
   nginx_proxy:
     volumes:
       - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.crt:ro
+      - /path/on/host/to/ssl.key:/etc/nginx/certs/yourdomain.com.key:ro
+
+  stations:
+    volumes:
+      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.key:ro
       - /path/on/host/to/ssl.key:/etc/nginx/certs/yourdomain.com.key:ro
 ```
 

--- a/docs/extending/modifying-docker.md
+++ b/docs/extending/modifying-docker.md
@@ -91,6 +91,6 @@ services:
 
   stations:
     volumes:
-      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.key:ro
+      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.crt:ro
       - /path/on/host/to/ssl.key:/etc/nginx/certs/yourdomain.com.key:ro
 ```

--- a/docs/extending/modifying-docker.md
+++ b/docs/extending/modifying-docker.md
@@ -78,14 +78,19 @@ services:
 
 ### Custom SSL Certificates
 
-If you want to supply your own SSL certificates instead of using the built-in LetsEncrypt service, you can mount your certificate files to the appropriate location using a `docker-compose.override.yml` file like this one:
+If you want to supply your own SSL certificates instead of using the built-in LetsEncrypt service, you can mount your certificate files to the appropriate locations using a `docker-compose.override.yml` file like this one:
 
 ```yaml
 version: '2.2'
 
 services:
-  web:
+  nginx_proxy:
     volumes:
-     - /path/to/your/ssl.crt:/etc/letsencrypt/ssl.crt:ro
-     - /path/to/your/ssl.key:/etc/letsencrypt/ssl.key:ro
+      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.crt:ro
+      - /path/on/host/to/ssl.key:/etc/nginx/certs/yourdomain.com.key:ro
+
+  stations:
+    volumes:
+      - /path/on/host/to/ssl.crt:/etc/nginx/certs/yourdomain.com.key:ro
+      - /path/on/host/to/ssl.key:/etc/nginx/certs/yourdomain.com.key:ro
 ```


### PR DESCRIPTION
I've updates the documentation on how to mount a custom SSL certificate on the `Modifying Docker` page and I also updated it on the `Enabling HTTPS with LetsEncrypt` page to add how to mount it to the stations container so that IceCast also uses it.