### PR TITLE
Updating documentation to account for InfluxDB removal

### DIFF
--- a/docs/about/README.md
+++ b/docs/about/README.md
@@ -60,7 +60,6 @@ Whether you're using the Bare-metal installer or Docker containers, AzuraCast wi
 * **[NGINX](https://www.nginx.com)** for serving web pages and the radio proxy
 * **[MariaDB](https://mariadb.org/)** as the primary database
 * **[PHP 7.2](https://secure.php.net/)** powering the web application
-* **[InfluxDB](https://www.influxdata.com/)** for time-series based statistics
 * **[Redis](https://redis.io/)** for sessions, database and general caching 
 
 ## Live Demo

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -40,7 +40,6 @@ In the same folder, run your platform's equivalent of:
 git clone https://github.com/AzuraCast/AzuraCast.git
 git clone https://github.com/AzuraCast/docker-azuracast-nginx-proxy.git
 git clone https://github.com/AzuraCast/docker-azuracast-db.git
-git clone https://github.com/AzuraCast/docker-azuracast-influxdb.git
 git clone https://github.com/AzuraCast/docker-azuracast-redis.git
 git clone https://github.com/AzuraCast/docker-azuracast-radio.git
 ```

--- a/docs/extending/modifying-docker.md
+++ b/docs/extending/modifying-docker.md
@@ -21,7 +21,6 @@ In summary, AzuraCast has five major containers that handle the application's fu
  - `stations`, which contains the broadcasting backend (Liquidsoap) and frontend (Icecast/SHOUTcast) for every station,
  - `mariadb` which contains the application database running on the MariaDB database engine,
  - `redis` which is a high-performance cache used for sessions and other cacheable data, and
- - `influxdb` which provides the time-series data that we use for our statistics and reporting tools.
 
  ### Docker Compose
 

--- a/docs/help/docker/README.md
+++ b/docs/help/docker/README.md
@@ -26,9 +26,9 @@ This message doesn't indicate anything is wrong with your installation; it is si
 
 ### "Problem with dial: dial tcp 172.18.X.X:XXXX: connect: connection refused. Sleeping 1s"
 
-This message is usually not an error. It's the result of a safety check we add into our Docker images, so they won't start up fully until other services (in this case, MariaDB, InfluxDB and Redis) are fully started and ready to accept connections. The "web" container periodically pings those services until they're fully started up, and if the service is still starting up, it will produce this "connection refused" error message, then retry again a second later.
+This message is usually not an error. It's the result of a safety check we add into our Docker images, so they won't start up fully until other services (in this case, MariaDB and Redis) are fully started and ready to accept connections. The "web" container periodically pings those services until they're fully started up, and if the service is still starting up, it will produce this "connection refused" error message, then retry again a second later.
 
-If your "web" container _never_ starts up, this could mean there is an error with one of your other containers (`mariadb`, `influxdb`, or `redis`). You can see what may be causing the problem by running `docker-compose logs -f servicename`, where `servicename` is one of the services listed in the previous sentence.
+If your "web" container _never_ starts up, this could mean there is an error with one of your other containers (`mariadb`, or `redis`). You can see what may be causing the problem by running `docker-compose logs -f servicename`, where `servicename` is one of the services listed in the previous sentence.
 
 ## Customizing Docker
 

--- a/docs/help/logs/README.md
+++ b/docs/help/logs/README.md
@@ -31,7 +31,6 @@ Since the Ansible installation interacts directly with your host server, its log
 - Supervisord: `/var/azuracast/www_tmp/supervisord.log`
 - Redis: `/var/log/redis/redis-server.log`
 - MariaDB: `/var/log/mysql`
-- InfluxDB: `/var/log/influxdb`
 
 For each station, logs for radio software will be inside `/var/azuracast/stations/{station_short_name}/config`, with the following filenames:
 


### PR DESCRIPTION
Ever since the recent commit to remove InfluxDB from AzuraCast, I don't believe it serves a purpose in the documentation anymore. One part I'm a bit 'confused' on is if it's required in the _/docs/developers/README.md_ since Influx was completely removed from AzuraCast, but a single repo of InfluxDB still remains: https://github.com/AzuraCast/docker-azuracast-influxdb

https://github.com/AzuraCast/AzuraCast/pull/3243
