### PR TITLE
Update now-playing-data.md

### DIFF
--- a/src/content/docs/docs/developers/now-playing-data.md
+++ b/src/content/docs/docs/developers/now-playing-data.md
@@ -279,3 +279,36 @@ sse.onmessage = (e) => {
   }
 };
 ```
+
+## Simple .txt file
+
+Sometimes you may want a simple plain text file containing `Artist - Title` information only. It may be relevant for legacy web players or other software.
+
+
+1. Go to `Station Profile` - `Broadcasting` - `Edit Liquidsoap Configuration`
+2. Paste the following code before `# Local Broadcasts` line and save configuration:
+
+An example of Liquidsoap code:
+
+```ruby
+def write_txt(m) =
+
+  if m["artist"] != "" then
+    ignore(file.write(data="#{m[\"artist\"]} - #{m[\"title\"]}", append=false, "/var/azuracast/www/web/static/nowplaying.txt"))
+  else
+    ignore(file.write(data="#{m[\"title\"]}", append=false, "/var/azuracast/www/web/static/nowplaying.txt"))
+  end
+
+end
+radio.on_metadata(write_txt)
+
+```
+Now you'll have `Artist - Title` nowplaying info available at _https://yourdomain.com/static/nowplaying.txt_
+
+For every station you can edit configuration and specify a name of .txt file:
+
+`"/var/azuracast/www/web/static/nowplaying_station1.txt"`
+
+`"/var/azuracast/www/web/static/nowplaying_station2.txt"`
+
+and so on.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. --> 
Following this thread https://github.com/AzuraCast/AzuraCast/issues/6903#issuecomment-1921292515 and requests on discord on how to do this:
Add guide to setup nowplaying via simple .txt file. Sometimes you may want a simple plain text file containing _Artist_ and _Title_ information only. It may be relevant for legacy web players or other software.
