### PR TITLE
Resolve #106 + other small details

### DIFF
--- a/src/content/docs/docs/administration/cloudflare.md
+++ b/src/content/docs/docs/administration/cloudflare.md
@@ -23,6 +23,7 @@ The default settings for Cloudflare will suffice, though you can also switch fro
 Once you've enabled Cloudflare support for your domain (or radio station's subdomain) from the Cloudflare control panel, you only need to enable one feature inside AzuraCast to enable listeners to connect:
 
 ### Enabling the Web Proxy for Radio Broadcasts
+
 One major limitation imposed by Cloudflare is that they do not forward incoming connections to your server that don't come from the traditional web ports (that is, 80 and 443). By default, AzuraCast serves each radio station on its own distinct port in a range from 8000 to 9000. This means your listeners wouldn't normally be able to connect.
 
 ![cloudflare_proxy.png](../images/cloudflare/cloudflare_proxy.png)
@@ -44,6 +45,7 @@ To create a new Page Rule:
 5) Click "Save and Deploy Page Rule" at the bottom of the page.
 
 Repeat these steps for all of the following patterns:
+
  - `/radio/*`
  - `/listen/*`
  - `/hls/*`

--- a/src/content/docs/docs/administration/command-line-interface.md
+++ b/src/content/docs/docs/administration/command-line-interface.md
@@ -41,7 +41,7 @@ This section will cover all account related CLI commands and the response the CL
 
 ### List all accounts
 
-```
+```bash
 (cli_command) azuracast:account:list 
 
 AzuraCast User Accounts
@@ -54,9 +54,9 @@ AzuraCast User Accounts
  ---------------- ------ --------------------- -------------------
 ```
 
-### Create a unique login recovery URL for the specified account.
+### Create a unique login recovery URL for the specified account
 
-``` 
+``` bash
 (cli_command) azuracast:account:login-token [example]
 
 Generate Account Login Recovery URL
@@ -69,9 +69,9 @@ Generate Account Login Recovery URL
  Log in using this temporary URL and set a new password using the web interface.
 ```
 
-### Reset the password of the specified account.
+### Reset the password of the specified account
 
-``` 
+``` bash
 (cli_command) azuracast:account:reset-password [example]
 
 Reset Account Password
@@ -84,9 +84,9 @@ Reset Account Password
  Log in using this temporary password and set a new password using the web interface.
  ```
 
-### Set the account specified as a global administrator.
+### Set the account specified as a global administrator
 
-``` 
+```bash
 (cli_command) azuracast:account:set-administrator [example]
 
 Set Administrator
@@ -97,66 +97,76 @@ Set Administrator
 
 ## API Related CLI Commands
 
-This section will cover our API related command(s), this'll be related to your AzuraCast's API. 
+This section will cover our API related command(s), this'll be related to your AzuraCast's API.
 
-### Regenerate AzuraCast's API documentation.
+### Regenerate AzuraCast's API documentation
 
-```
+```bash
 (cli_command) azuracast:api:docs
 
 API documentation updated!
 ```
+
 This command should be used when you're on a development, production or testing machine and you're making modifications to the API, this will update your API accordingly (domain/api)
 
 ## Internal CLI Commands
 
-This section will cover our internal processes, such as Liquidsoap, SSL and SFTP authentication. 
+This section will cover our internal processes, such as Liquidsoap, SSL and SFTP authentication.
 
 ### Get the external IP address for this instance
 
-```
+```bash
 (cli_command) azuracast:internal:ip
 
 [example]
 ```
-Running this command will return the IP of this machine. 
+
+Running this command will return the IP of this machine.
 
 ###  Handle Liquidsoap API calls
 
-```
+```bash
 (cli_command) azuracast:internal:liquidsoap [example] [example]
 ```
 This command can run various Liquidsoap API calls, this is primarily used for debugging or development purposes.
 
 ### Reload broadcast frontends when an SSL certificate changes
-```
+
+```bash
 (cli_command) azuracast:internal:on-ssl-renewal
 ```
 
 ### Attempt SFTP Authentication
-```
+
+```bash
 (cli_command) azuracast:internal:sftp-auth
 ```
 
-### Send upcoming song feedback from the AutoDJ back to AzuraCast.
-```
+### Send upcoming song feedback from the AutoDJ back to AzuraCast
+
+```bash
 (cli_command) azuracast:internal:sftp-event
 ```
 
 ## AzuraCast Settings CLI Commands
+
 This section will cover our internal internal settings ranging from base URL to smtp. This can be used should you be locked out of the settings or unable to access AzuraCast directly from the browser.  
 
 ### List all settings for AzuraCast
-```
+
+```bash
 (cli_command) azuracast:settings:list
 ```
-This command will return all the settings you can modify via the Command Line Interface, which will be shown in the next field. 
+
+This command will return all the settings you can modify via the Command Line Interface, which will be shown in the next field.
 
 ### Modify settings for AzuraCast
-```
+
+```bash
 (cli_command) azuracast:settings:set [example] [example]
 ```
-The `setting-key` parameter can be collected from the `settings:list` CLI command, this command will allow you to modify almost all portions of AzuraCast's settings, this is useful should you be having issues with misconfigured settings. 
+
+The `setting-key` parameter can be collected from the `settings:list` CLI command, this command will allow you to modify almost all portions of AzuraCast's settings, this is useful should you be having issues with misconfigured settings.
 
 ### Manually Run AzuraCast Setup
 

--- a/src/content/docs/docs/administration/customization.md
+++ b/src/content/docs/docs/administration/customization.md
@@ -22,9 +22,11 @@ $(document).on('now-playing', function(np_new) {
 ```
 
 ### Example: Video Playback for Public Page
-You can use `Custom JS for Public Pages` to add a video element to the page and style via the `Custom CSS for Public Pages` using our example below. 
+
+You can use `Custom JS for Public Pages` to add a video element to the page and style via the `Custom CSS for Public Pages` using our example below.
 
 **Custom CSS for Public Pages**
+
 ```css
 [data-theme] body.page-minimal .background-video {
 	width: 100vw;
@@ -38,7 +40,9 @@ You can use `Custom JS for Public Pages` to add a video element to the page and 
 	z-index: -1;
 }
 ```
+
 **Custom JS for Public Pages**
+
 ```javascript
 let videoBackgroundElement = document.createElement('video');
 videoBackgroundElement.autoplay = true;

--- a/src/content/docs/docs/administration/docker.md
+++ b/src/content/docs/docs/administration/docker.md
@@ -25,14 +25,14 @@ If you've recently followed the [Docker installation instructions](/docs/getting
 
 If you have an older installation, you can use the Docker Utility Script by running these commands inside your AzuraCast directory on your host computer:
 
-```
+```bash
 curl -L https://raw.githubusercontent.com/AzuraCast/AzuraCast/main/docker.sh > docker.sh
 chmod a+x docker.sh
 ```
 
 ### Run Command Line Tools
 
-```
+```bash
 ./docker.sh cli [command_name]
 ```
 
@@ -42,7 +42,7 @@ Runs any command exposed by the command line interface tools.
 
 ### Install AzuraCast
 
-```
+```bash
 ./docker.sh install
 ```
 
@@ -50,7 +50,7 @@ Pulls the latest version of all Docker images and sets up the AzuraCast database
 
 ### Update AzuraCast
 
-```
+```bash
 ./docker.sh update-self
 ./docker.sh update
 ```
@@ -61,7 +61,7 @@ Automatically pulls down any updated Docker images and applies any database and 
 
 ### Uninstall AzuraCast
 
-```
+```bash
 ./docker.sh uninstall
 ```
 
@@ -73,7 +73,7 @@ This command will fully remove any station media, statistics and metrics, and th
 
 ### Back Up Files and Settings
 
-```
+```bash
 ./docker.sh backup [/path/to/backup.tar.gz]
 ```
 
@@ -81,7 +81,7 @@ Creates a .tar.gz backup copy of the media, statistics and metrics of every stat
 
 ### Restore Files and Settings
 
-```
+```bash
 ./docker.sh restore /path/to/backup.tar.gz
 ```
 
@@ -143,7 +143,7 @@ There are some considerations when creating your own `docker-compose.override.ym
 
 Once you've modified your Docker Compose configuration, you should apply these changes by running:
 
-```sh
+```bash
 docker-compose down
 docker-compose up -d
 ```
@@ -171,7 +171,7 @@ To override more complex functionality in your Docker installation, see the "Cus
 # Expanding the Station Port Range
 
 :::tip
-Installations running version 0.16.0 or higher can now use our installation script to customizez ports via the terminal which will automatically write the changes into the `docker-compose.yml` file for you. 
+Installations running version 0.16.0 or higher can now use our installation script to customizez ports via the terminal which will automatically write the changes into the `docker-compose.yml` file for you.
 :::
 
 For performance reasons, by default Docker installations only open radio ports from port 8000 to 8500. This allows for 50 unique stations to operate.
@@ -339,7 +339,7 @@ You should increase the value until the error dissappears.
 
 The `M` after the value stands for `Megabytes`.
 
-Refer to the following page for more information about the allowed values for this setting: https://www.php.net/manual/docs/faq.using.php#faq.using.shorthandbytes
+Refer to [PHP's documentation](https://www.php.net/manual/docs/faq.using.php#faq.using.shorthandbytes) for more information about the allowed values for this setting.
 
 After you have changed this setting you need to restart AzuraCast via `docker-compose down && docker-compose up -d`.
 

--- a/src/content/docs/docs/administration/roles-and-permissions.md
+++ b/src/content/docs/docs/administration/roles-and-permissions.md
@@ -16,7 +16,7 @@ AzuraCast has a highly granular Access Control List (ACL) system that allows you
 
 In summary, you can think of the access control list as working this way:
 
-- One or more **Users** can be in a **Role**. 
+- One or more **Users** can be in a **Role**.
 - Each **Role** has one or more **Permissions**, which gives everyone in that Role that level of access. Permissions can either be specific to a single station, or global for the entire installation.
 
 The Roles & Permissions page has protections in place to prevent users from accidentally denying themselves permissions to the Permissions page itself.

--- a/src/content/docs/docs/administration/ssl-and-lets-encrypt.md
+++ b/src/content/docs/docs/administration/ssl-and-lets-encrypt.md
@@ -40,7 +40,7 @@ To enable LetsEncrypt, follow these steps:
 The HTTPS certificate will automatically be generated in the next few minutes, but you can do it manually by clicking the "Create/Renew Certificate" button under the LetsEncrypt fields.
 
 :::tip
-If users are still having issues with audio not playing, please ensure you have the "Use Web Proxy" option enabled in your System Settings. 
+If users are still having issues with audio not playing, please ensure you have the "Use Web Proxy" option enabled in your System Settings.
 :::
 
 ### Renewing a Let's Encrypt Certificate

--- a/src/content/docs/docs/administration/sync-tasks.md
+++ b/src/content/docs/docs/administration/sync-tasks.md
@@ -38,7 +38,7 @@ SYNC_LONG_EXECUTION_TIME=2200
 
 After changing these entries restart your AzuraCast installation via:
 
-```
+```bash
 docker-compose down
 docker-compose up -d
 ```

--- a/src/content/docs/docs/developers/apis.md
+++ b/src/content/docs/docs/developers/apis.md
@@ -22,7 +22,7 @@ Once installed and running, AzuraCast exposes an API that allows you to monitor 
 
 Each AzuraCast installation includes documentation for the API at the exact version it's currently using. In our public documentation, we include the API as of the latest Rolling Release version.
 
-- [/api](View API Documentation)
+- [View API Documentation](/api)
 
 ## API Authentication
 

--- a/src/content/docs/docs/developers/getting-started.md
+++ b/src/content/docs/docs/developers/getting-started.md
@@ -46,7 +46,7 @@ Using Git, clone the AzuraCast core repository into a subfolder of your working 
 
 > **Note for Windows developers:** Before cloning the repositories, you should ensure your Git is locally configured to not automatically convert line endings from Linux style (LF) to Windows style (CRLF), which will break AzuraCast. You can set this globally by running:
 > 
-> ```sh
+> ```bash
 > git config --global core.autocrlf input
 > ```
 

--- a/src/content/docs/docs/developers/now-playing-data.md
+++ b/src/content/docs/docs/developers/now-playing-data.md
@@ -13,6 +13,7 @@ sidebar:
 The most important and frequently accessed pieces of information that AzuraCast stores are all served as part of a single group of data, which we refer to as the "Now Playing" data.
 
 This data includes:
+
  - Basic information about the station, its mount points and remote relays;
  - Current listener counts, including total and unique listeners;
  - The currently playing song, including a timestamp of when it was started, and whether it came from a playlist, request, or live source;

--- a/src/content/docs/docs/developers/plugins.md
+++ b/src/content/docs/docs/developers/plugins.md
@@ -11,7 +11,7 @@ AzuraCast contains a plugin system that can be used to extend AzuraCast without 
 
 ## Example Plugin
 
-We have built an example plugin that you should use as the base for your own plugin. You can find the git repository at: 
+We have built an example plugin that you should use as the base for your own plugin. You can find the git repository at:
 
 https://github.com/AzuraCast/example-plugin
 

--- a/src/content/docs/docs/getting-started/installation/windows.md
+++ b/src/content/docs/docs/getting-started/installation/windows.md
@@ -26,7 +26,7 @@ When running the installer, you will be prompted to automatically set up your Wi
 
 Once WSL2 is installed and configured, and Docker Desktop is up and running, open a terminal window and type the following command:
 
-```
+```bash
 wsl --set-default-version 2
 ```
 
@@ -44,13 +44,13 @@ For convenience, you can set the newly installed distribution as your "default" 
 
 You can list the names of all installed WSL2 distributions by running:
 
-```
+```bash
 wsl --list
 ```
 
 To set one as your default, enter its name in the command below. If you followed the recommendations here and used Ubuntu, you can run this command:
 
-```
+```bash
 wsl --set-default Ubuntu
 ```
 

--- a/src/content/docs/docs/getting-started/requirements.md
+++ b/src/content/docs/docs/getting-started/requirements.md
@@ -17,17 +17,19 @@ AzuraCast does not ensure, and is not liable for, music licenses and royalties p
 ## 🖥️ System Requirements
 
 ### Minimum Requirements
+
 - A 64-bit x86 (x86_64/amd64) or ARM64 CPU
 - at least 2GB of RAM
 - 20GB or greater of hard drive space
 - A computer/server capable of running Docker
 
-For Linux hosts, the `sudo`, `curl` and `git` packages should be installed before installing AzuraCast. Most Linux distributions include these packages already. This is the barest of minimum to run AzuraCast, there's no guarantees it will run perfectly. 
+For Linux hosts, the `sudo`, `curl` and `git` packages should be installed before installing AzuraCast. Most Linux distributions include these packages already. This is the barest of minimum to run AzuraCast, there's no guarantees it will run perfectly.
 
 ### Recommended Requirements
+
 - 4 CPU cores
-- 4GB of ram. 
-- 40 GB or greater of hard drive space 
+- 4GB of ram
+- 40 GB or greater of hard drive space
 - A computer/server capable of running Docker
 
 Recommeneded Requirements should allow  you to run a few stations with ease, this is aimed for hobby usage (5 to 10 stations). [If you wish to increase the memory even further, consult this guide on Swap Space](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04)
@@ -42,7 +44,7 @@ We strongly recommend one of the following distributions and versions for your A
 
 - Ubuntu 22.04 LTS (Docker only)
 - Ubuntu 20.04 LTS (Ansible / Docker)
-- Ubuntu 18.04 LTS (Docker only) 
+- Ubuntu 18.04 LTS (Docker only)
 - Debian 10 "Buster" (Ansible / Docker)
 - Debian 9 "Stretch" (Ansible / Docker)
 - MacOS - Using Docker Desktop

--- a/src/content/docs/docs/getting-started/settings.md
+++ b/src/content/docs/docs/getting-started/settings.md
@@ -50,10 +50,13 @@ The default `azuracast.env` contains the following variables:
 
 | Variable | Default Value | Description
 | - | - | -
+| `LANG` | en_US | The locale to use for CLI commands. <br> Valid options: `en_US`, `cs_CZ`, `nl_NL`, `fr_FR`, `de_DE`, `el_GR`, `it_IT`, `ja_JP`, `ko_KR`, `nb_NO`, `pl_PL`, `pt_PT`, `pt_BR`, `ru_RU`, `zh_CN`, `es_ES`, `sv_SE`, `tr_TR`, `uk_UA`
 | `APPLICATION_ENV` | production | The application environment. <br> Valid options: `production`, `development`, `testing`
 | `LOG_LEVEL` | notice | This allows you to log debug-level errors temporarily (for problem-solving) or reduce the volume of logs that are produced by your installation, without needing to modify whether your installation is a production or development instance.<br> Valid options: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`
 | `COMPOSER_PLUGIN_MODE` | false | Enable the composer "merge" functionality to combine the main application's composer.json file with any plugins' composer files. This can have performance implications, so you should only use it if you use one or more plugins with their own Composer dependencies. <br> Valid options: true, false
 | `AUTO_ASSIGN_PORT_MIN` | 8000 | The minimum port number to use when automatically assigning ports to a station. By default, this matches the first forwarded port on the "stations" container. You can modify this variable if your station port range is different. Be sure to also forward the necessary ports via `docker-compose.yml` (and nginx, if you want to use the built-in port-80/443 proxy)!
+| `AUTO_ASSIGN_PORT_MAX` | 8499 | The maximum port number to use when automatically assigning ports to a station. If using the default `AUTO_ASSIGN_PORT_MIN` OF 8000, using the default 8499 allows for 50 unique stations to operate.
+| `SHOW_DETAILED_ERRORS` | false | This allows you to debug Slim Application Errors you may encounter. By default, this is disabled to prevent users from seeing privileged information. Please report any Slim Application Error logs [to the development team on GitHub](https://github.com/slimphp/Slim/issues).
 
 ### Database Configuration
 
@@ -65,8 +68,10 @@ The default `azuracast.env` contains the following variables:
 | `MYSQL_PASSWORD` | azur4c457 | The password AzuraCast will use to connect to the database. By default, the database is not exposed to the Internet at all and this is only an internal password used by the service itself.
 | `MYSQL_DATABASE` | azuracast | The name of the AzuraCast database.
 | `MYSQL_RANDOM_ROOT_PASSWORD` | yes | Automatically generate a random root password upon the first database spin-up. This password will be visible in the mariadb container's logs.
-| `MYSQL_SLOW_QUERY_LOG` | 0 | Log slower queries for the purpose of diagnosing issues. Only turn this on when you need to, by uncommenting this and switching it to 1. To read the slow query log once enabled, run: `docker-compose exec mariadb slow_queries`
+| `MYSQL_SLOW_QUERY_LOG` | 0 | Log slower queries for the purpose of diagnosing issues. Only turn this on when you need to, by uncommenting this and switching it to 1. <br> To read the slow query log once enabled, run: `docker-compose exec mariadb slow_queries`
 | `MYSQL_MAX_CONNECTIONS` | 100 | Set the amount of allowed connections to the database. This value should be increased if you are seeing the `Too many connections` error in the logs.
+| `MYSQL_INNODB_BUFFER_POOL_SIZE` | 128M | The InnoDB buffer pool size controls how much data & indexes are kept in memory. Making sure that this value is as large as possible reduces the amount of disk IO.
+| `MYSQL_INNODB_LOG_FILE_SIZE` | 16M | The InnoDB log file is used to achieve data durability in case of crashes or unexpected shutoffs and to allow the DB to better optimize IO for write operations.
 
 ### Redis Configuration
 
@@ -76,7 +81,8 @@ Do not modify these fields if you are using the standard AzuraCast Redis host.
 
 | Variable | Default Value | Description
 | - | - | -
-| `REDIS_HOST` | redis | Name of the Redis host.
+| `ENABLE_REDIS` | true | Disable to use a flatfile cache instead of Redis.
+| `REDIS_HOST` | localhost | Name of the Redis host.
 | `REDIS_PORT` | 6379 | Port to connect to on the Redis host.
 | `REDIS_DB` | 1 | Database index to use on the Redis host.
 
@@ -89,6 +95,12 @@ Do not modify these fields if you are using the standard AzuraCast Redis host.
 | `PHP_MAX_EXECUTION_TIME` | 30 | PHP's maximum script execution time (in seconds).
 | `SYNC_SHORT_EXECUTION_TIME` | 600 | The maximum execution time (and lock timeout) for the 15-second, 1-minute and 5-minute synchronization tasks.
 | `SYNC_LONG_EXECUTION_TIME` | 1800 | The maximum execution time (and lock timeout) for the 1-hour synchronization task.
+| `NOW_PLAYING_DELAY_TIME` | 10 | The delay (in seconds) between Now Playing checks for every station. Decrease for more frequent checks at the expense of performance; increase for less frequent checks but better performance (for large installations). Minimum of 5 and maximum of 60 seconds.
+| `NOW_PLAYING_MAX_CONCURRENT_PROCESSES` | 1/3rd the total number of stations, rounded up | The maximum number of concurrent processes for now playing updates. Increasing this can help reduce the latency between updates now playing updates on large installations.
 | `PHP_FPM_MAX_CHILDREN` | 5 | Maximum number of PHP-FPM worker processes to spawn.
-| `ADDITIONAL_MEDIA_SYNC_WORKER_COUNT` | 0 | Create additional media sync worker processes. This setting can be used to increase the performance of the media sync process by creating additional worker processes to consume messages
 | `PROFILING_EXTENSION_ENABLED` | 0 | Enable the SPX profiling extension in the Docker container, allowing for performance analysis of each page load.
+| `PROFILING_EXTENSION_ALWAYS_ON` | false | This will have a significant performance impact on your installation.
+| `PROFILING_EXTENSION_HTTP_KEY` | dev | The value for the "SPX_KEY" parameter for viewing profiling pages.
+| `NGINX_CLIENT_MAX_BODY_SIZE` | 50M | This is the total size any single request body can be. AzuraCast chunks its uploads into smaller file sizes, so this only applies when doing custom uploads via the API. Sizes should be listed in a format like "100K", "128M", "1G" for kilobytes, megabytes, and gigabytes respectively.
+| `ENABLE_WEB_UPDATER` | true | Enable web-based Docker image updates.
+| `INSTALL_PACKAGES_ON_STARTUP` | none | Extra Ubuntu packages to install upon startup. Separate package names with a space. Packages will be installed during container startup.

--- a/src/content/docs/docs/help/logs.md
+++ b/src/content/docs/docs/help/logs.md
@@ -16,7 +16,7 @@ Users with the appropriate permissions can also view many logs directly through 
 
 If you are administrating your own AzuraCast installation you can check most logs through the `Administration` -> `System Logs`.
 
-In addition to the `Icecast`, `SHOUTcast` and `Liquidsoap` logs you can find the `AzuraCast Application Log` here which contains useful information about what the AzuraCast application itself is doing.
+In addition to the `Icecast`, `SHOUTcast` and `Liquidsoap` logs you can find the `AzuraCast Application Log` here which contains useful information about what the AzuraCast application itself is doing. Email message logs are also sent here.
 
 ## Log Viewer
 
@@ -27,7 +27,7 @@ In addition to the logs, you can also view the Icecast, SHOUTcast and Liquidsoap
 ## Log Types
 
 ### AzuraCast Application Log
- 
+
 This log file contains the log output of the AzuraCast application itself. If you encounter any errors with the application itself you will most likely find more information about those errors in this log file.
 
 ### Liquidsoap Log
@@ -73,6 +73,6 @@ Since the Ansible installation interacts directly with your host server, its log
 
 For each station, logs for radio software will be inside `/var/azuracast/stations/{station_short_name}/config`, with the following filenames:
 
- - Liquidsoap: `liquidsoap.log`
- - Icecast: `icecast.log`
- - SHOUTcast: `sc_serv.log`
+- Liquidsoap: `liquidsoap.log`
+- Icecast: `icecast.log`
+- SHOUTcast: `sc_serv.log`

--- a/src/content/docs/docs/help/optimizing.md
+++ b/src/content/docs/docs/help/optimizing.md
@@ -17,8 +17,9 @@ If you're running AzuraCast on limited system resources, you may find that you n
 If Replaygain is enabled in your AutoDJ, then Liquidsoap will examine each file to see if it already has Replaygain metadata associated with it; if not, it will try to automatically calculate it on-the-fly, which can be a very CPU-intensive process that can significantly slow your installation.
 
 In order to resolve this, you can take one of two approaches:
-1) Disable Replaygain from the "AutoDJ" tab of your station's profile; or
-2) Ensure all of your uploaded media is pre-tagged with Replaygain metadata using a tool like [loudgain](https://github.com/Moonbase59/loudgain).
+
+1. Disable Replaygain from the "AutoDJ" tab of your station's profile; or
+2. Ensure all of your uploaded media is pre-tagged with Replaygain metadata using a tool like [loudgain](https://github.com/Moonbase59/loudgain)
 
 ### Disable Audio Post-Processing
 
@@ -26,10 +27,10 @@ If your installation is limited in available CPU, you should disable any "Audio 
 
 The total amount of extra resources per station consumed by post-processing is roughly as so:
 
- - Stereo Tool (Most CPU)
- - `master_me` (Med-High CPU)
- - Basic Compression/Normalization (Low-Med CPU)
- - No Post-Processing (Least CPU)
+- Stereo Tool (Most CPU)
+- `master_me` (Med-High CPU)
+- Basic Compression/Normalization (Low-Med CPU)
+- No Post-Processing (Least CPU)
 
 ### AutoCue
 

--- a/src/content/docs/docs/help/report-a-bug.md
+++ b/src/content/docs/docs/help/report-a-bug.md
@@ -20,7 +20,7 @@ If your issue isn't in our known issues or common solutions, check out our [GitH
 
 If there's already an open GitHub issue for the specific issue you're having, you can follow that issue for updates. If not, you can create a new issue from the same page.
 
-When creating a new issue, you'll be presented with a template of questions to answer to help our team provide quick and accurate support. 
+When creating a new issue, you'll be presented with a template of questions to answer to help our team provide quick and accurate support.
 
 **Please make sure to answer these questions and provide as much detail as possible!**
 

--- a/src/content/docs/docs/help/troubleshooting.md
+++ b/src/content/docs/docs/help/troubleshooting.md
@@ -35,23 +35,26 @@ php /var/azuracast/www/bin/console cache:clear
 
 ## Common Docker Errors
 
-### "Invalid interpolation format" related errors. 
-This issue is related to an out of date docker-compose version, since we use a more up to date docker-compose version it'll return these types of errors. 
+### "Invalid interpolation format" related errors
+
+This issue is related to an out of date docker-compose version, since we use a more up to date docker-compose version it'll return these types of errors.
 
 - `ERROR: Invalid interpolation format for "installer" option in service "services": "ghcr.io/azuracast/web:${AZURACAST_VERSION:-latest}"`
 - `ERROR: Invalid interpolation format for "nginx_proxy" option in service "services": "ghcr.io/azuracast/nginx_proxy:${AZURACAST_VERSION:-latest}"`
 
+The solution is simple, run these commands. You may need to run it with `sudo` permissions:
 
-Solution is simple, run this command. You may need to run it with `sudo` permissions. 
-
-- `./docker.sh install-docker-compose`
-- Run the command `./docker.sh install`
+```bash
+./docker.sh install-docker-compose
+./docker.sh install
+```
 
 ### "bind: address already in use"
 
 If you get this error when starting the Docker AzuraCast instance, it means that something else (some other process or server software) is already running on the same port(s) that AzuraCast is trying to reserve for itself.
 
 There are generally two ways to resolve this:
+
 - Find the process that's currently listening on the port (commands like `netstat -tulpn` can help you with this) and either disable the program that's currently listening, edit its configuration to change the port it listens on, or uninstall it from the server completely.
 - Switch the port AzuraCast uses for its own traffic to an unused one. [See instructions](/docs/administration/docker)
 
@@ -65,7 +68,7 @@ This message doesn't indicate anything is wrong with your installation; it is si
 
 ## Other General Errors
 
-### InnoDB: Upgrade after a crash is not supported.
+### InnoDB: Upgrade after a crash is not supported
 
 The DB crashed while using MariaDB 10.4 and was then not restarted with the same MariaDB version so that it can recover from the redo log files but was updated to 10.5 which now is not able to handle the old redo log format (in 10.5 they changed that format).
 
@@ -97,12 +100,11 @@ This situation is one of the primary reasons why we strongly encourage users to 
 
 We don't provide specific instructions for this process as it can cause irreparable damage to your installation, but basically, the process would be:
 
- - Identify which migration is failing.
- - Find the corresponding migration (in the `src/Entity/Migrations` folder).
- - Find which step is failing in the `up` function, and find the corresponding SQL commands to undo those specific migrations in the `down` command in the same file.
- - Manually run those commands via 
-   `./docker.sh cli dbal:run-sql "SQL COMMAND HERE"`
- - Re-run the update process.
+- Identify which migration is failing.
+- Find the corresponding migration (in the `src/Entity/Migrations` folder).
+- Find which step is failing in the `up` function, and find the corresponding SQL commands to undo those specific migrations in the `down` command in the same file.
+- Manually run those commands via `./docker.sh cli dbal:run-sql "SQL COMMAND HERE"`
+- Re-run the update process.
 
 ## Submitting an Issue
 

--- a/src/content/docs/docs/user-guide/sftp-server.md
+++ b/src/content/docs/docs/user-guide/sftp-server.md
@@ -37,6 +37,7 @@ Note, this is a file named `.env`, with no filename, and not the `azuracast.env`
 ## Connecting to SFTP
 
 ### SFTP clients
+
 Here's a small list of FTP clients you can use that are known to work with AzuraCast's SFTP system.
 
 - [Filezilla](https://filezilla-project.org/) - Windows, MacOS and Linux 32 bit & 64 bit

--- a/src/content/docs/docs/user-guide/streamers-and-djs.md
+++ b/src/content/docs/docs/user-guide/streamers-and-djs.md
@@ -23,4 +23,3 @@ We have guides for how to configure many kinds of popular streaming software. Se
 ## Recording Broadcasts
 
 You can opt to record live broadcasts by editing the station's profile. Broadcasts will automatically be recorded in the format and bitrate that you specify, and can be downloaded from the "Broadcasts" popup menu next to each streamer.
-

--- a/src/content/docs/docs/user-guide/streaming-software.md
+++ b/src/content/docs/docs/user-guide/streaming-software.md
@@ -138,19 +138,19 @@ Note 2: Be sure to select `v1`, as v2 will append the Stream ID (SID), which won
 
 6. Finish by changing the rest of the settings by preference:
 
-  - Connection
-    - Sample Rate
-    - Encoder
-    - Bitrate
-    - Channels
+- Connection
+  - Sample Rate
+  - Encoder
+  - Bitrate
+  - Channels
 
   - Station info
 
     If needed, here you can override the info that can be found in the main `Settings` (From step 1), under `Broadcasting` -> `Metadata`
 
-7. Then finally click `OK` to save the Encoder.
+1. Then finally click `OK` to save the Encoder.
 
-8. In the Settings window, check the checkboxes for all encoders that you want to use.
+2. In the Settings window, check the checkboxes for all encoders that you want to use.
 Remember to turn on the option `Broadcasting enabled` on top.
 
 On succesful connection, the log report in the bottom-left corner of RadioBOSS will show the following message: "Connected to server! (Output N)". This means that listeners can now connect to the streaming server (either Icecast or ShoutCast).
@@ -160,6 +160,7 @@ If the logs show "[E40] Cannot start broadcast" in red, go over the above steps.
 More information can be found in the RadioBOSS Help System. Press `Ctrl+F1` inside the RadioBOSS application, or in the top menu bar go to `Help` -> `Contents`.
 
 The following articles in there are helpful:
+
 - `Operation` -> `Broadcasting Internet radio`
 - `Options` -> `Broadcast`
 - `Options` -> `Broadcast` -> `Metadata`
@@ -180,26 +181,26 @@ The installation steps for the plugin are relatively simple, so they're not cove
 
 These instructions are valid and required for both streaming modes (Icecast and SHOUTcast), so be sure to follow this part before proceeding any further.
 
- **1.** After installing the Internet Broadcast plugin, select the menu **Plugins** menu, on the top menu bar and select the **Plugin Manager...** option.
+ 1. After installing the Internet Broadcast plugin, select the menu **Plugins** menu, on the top menu bar and select the **Plugin Manager...** option.
 
 ![Plugins menu](../images/streaming-software/playitlive_1.png)
 
 *Select the Plugins menu, then the Plugin Manager option*
 
- **2.** A new window should appear, and within it the Internet Broadcast plugin.
- 
+2. A new window should appear, and within it the Internet Broadcast plugin.
+
 ![Plugin Manager](../images/streaming-software/playitlive_2.png)
 *The Plugin Manager window*
 
- **3.** Open the plugin settings, by double clicking on it's name. This window should appear.
+3. Open the plugin settings, by double clicking on it's name. This window should appear.
 
 ![Plugin settings](../images/streaming-software/playitlive_3.png)
 *Plugin Settings*
 
 **There are a few settings that you can customize here:**
 
- - In **Audio source to broadcast** you can define which input is going to be transmited to the server;
- - **Auto start streams** let's you start streaming after opening the software.
+- In **Audio source to broadcast** you can define which input is going to be transmited to the server;
+- **Auto start streams** let's you start streaming after opening the software.
 
 **4.** Under **Streams**, click **Add** to add a new streaming server.
 
@@ -221,13 +222,10 @@ Now follow the specific instructions for your streaming server: **Icecast** or *
 
 **Don't forget to change these details with yours, this is just an example!**
 
-**Notes:** 
+**Notes:**
 
- - The **Save audio to file** field can be left unchecked. Check it if
-   you want to record the stream into a MP3 file.
-   
-  - Under **Audio**, select the audio bitrate and the format (stereo or
-   mono) that matches your station.
+- The **Save audio to file** field can be left unchecked. Check it if you want to record the stream into a MP3 file.
+- Under **Audio**, select the audio bitrate and the format (stereo or mono) that matches your station.
 
 **2.** After filling the form fields, click **OK** to save the server details.
 
@@ -250,18 +248,13 @@ If the server is configured correctly, the **OFF AIR** text will change to **ON 
 
 **Don't forget to change these details with yours, this is just an example!**
 
-**Notes:** 
+**Notes:**
 
- - In **Server Type**, select SHOUTcast v1.
+- In **Server Type**, select SHOUTcast v1.
+- The **Password** field must be in this format: `dj_username:dj_password`
+- The **Save audio to file** field can be left unchecked. Check it if you want to record the stream into a MP3 file.
+- Under **Audio**, select the audio bitrate and the format (stereo or mono) that matches your station.
 
- - The **Password** field must be in this format: `dj_username:dj_password`
- 
- - The **Save audio to file** field can be left unchecked. Check it if
-   you want to record the stream into a MP3 file.
-  
-  - Under **Audio**, select the audio bitrate and the format (stereo or
-   mono) that matches your station.
-   
 **2.** After filling the form fields, click **OK** to save the server details.
 
 **3.** To start broadcasting, click on Start Streams here on in the main interface of the software.


### PR DESCRIPTION
**Fixes issue:**
#106 

**Proposed changes:**
* Adds missing `azuracast.env` settings that have been added in recent versions
* Remove `ADDITIONAL_MEDIA_SYNC_WORKER_COUNT` as I couldn't find it used anymore in the project - looked to be outdated?
* I've seen it said that `NOW_PLAYING_MAX_CONCURRENT_PROCESSES` defaults to 5, however, I didn't see this reflected in the code - happy to change this if I missed something, but it looks like this default # will vary between installations
* Similarly, it is said that `REDIS_HOST` is set to `redis` for Docker installations, but it looks like it will always set to `localhost` - perhaps this was never updated either, or I am missing something.
* A myriad of small details / markdown syntax corrections / consistency enforcement across the entire docs aimed at resolving markdownlint issues + cleanliness