### PR TITLE
Resolve "Did Not Connect: Potential Security Issue" HSTS error when navigating from local installation

### DIFF
--- a/builtin/astro.config.mjs
+++ b/builtin/astro.config.mjs
@@ -27,8 +27,8 @@ export default defineConfig({
       sidebar: [
         { label: 'About These Docs', link: '/' },
         { label: 'Live Documentation', link: 'https://www.azuracast.com/docs' },
-        { label: 'API Documentation', link: '/api' },
-        { label: 'Update AzuraCast', link: '/getting-started/updates' },
+        { label: 'API Documentation', link: '/api/' },
+        { label: 'Update AzuraCast', link: '/getting-started/updates/' },
         {
           label: 'Help',
           autogenerate: { directory: 'help' },


### PR DESCRIPTION
**Proposed changes:**

- Write the relative URLs in the sidebar with a trailing slash - this fixes an issue where clicking the buttons in local AzuraCast docs leads to a HSTS error

Admittedly, I don't know whether this has implications for other setups - I just know it has resolved the problem for us. Happy to provide more info as needed. Thank you!